### PR TITLE
Fixed: Typo in Map

### DIFF
--- a/lib/packages/loading.dart
+++ b/lib/packages/loading.dart
@@ -16,7 +16,7 @@ class _LoadingState extends State<Loading> {
     await instance.getTime();
     Navigator.pushReplacementNamed(context,'/home',arguments:{
     'location':instance.location,
-    'time ':instance.time,
+    'time':instance.time,
     'flag':instance.flag,});
   }
   void initState(){


### PR DESCRIPTION
A typo causes an error in the key definition.
'time ' is different from 'time'
' ' -> this space is considered a valid essential character in a key definition.